### PR TITLE
ci: add backend Go validation workflow

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,69 @@
+name: Backend CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - backend/**
+      - .github/workflows/backend-ci.yml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - backend/**
+      - .github/workflows/backend-ci.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backend-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend-validate:
+    name: Build, Vet, and Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: group_events_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d group_events_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    defaults:
+      run:
+        shell: bash
+        working-directory: backend
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/group_events_test?sslmode=disable
+      GOFLAGS: -buildvcs=false
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Build backend
+        run: go build ./...
+
+      - name: Vet backend
+        run: go vet ./...
+
+      - name: Test backend
+        run: go test -race ./...


### PR DESCRIPTION
## Summary\n- add backend CI workflow for pushes and PRs targeting main\n- scope execution to backend path changes and workflow updates\n- run checkout, setup-go, build, vet, and race-enabled tests\n- include PostgreSQL service container for DB-backed backend tests\n\n## Acceptance Criteria Mapping (Issue #11)\n- trigger on push to main and pull_request to main: ✅\n- path filter for backend/**: ✅\n- build/vet/test -race steps: ✅\n- postgres service container: ✅\n- build badge in root README: ✅ (already present on main)\n\n## Validation\n- backend checks verified locally before PR creation\n\nCloses #11