### PR TITLE
feat: complete core domain models and SDUI validation

### DIFF
--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -34,6 +34,8 @@ func (r Role) CanRespond() bool {
 	return r == RoleOwner || r == RoleAdmin || r == RoleOrganizer || r == RoleMember
 }
 
+// Group is the top-level collaboration boundary.
+// Validation rule: ID, slug, and name must all be non-empty.
 type Group struct {
 	ID          GroupID    `json:"id"`
 	Slug        string     `json:"slug"`
@@ -44,11 +46,31 @@ type Group struct {
 	ArchivedAt  *time.Time `json:"archivedAt,omitempty"`
 }
 
+func (g Group) IsValid() bool {
+	return g.ID != "" && g.Slug != "" && g.Name != ""
+}
+
+// Member represents an identity that can join one or more groups.
+// Validation rule: ID and display name must be non-empty.
+type Member struct {
+	ID          UserID `json:"id"`
+	DisplayName string `json:"displayName"`
+	AvatarURL   string `json:"avatarUrl,omitempty"`
+}
+
+func (m Member) IsValid() bool {
+	return m.ID != "" && m.DisplayName != ""
+}
+
 type Membership struct {
 	GroupID  GroupID   `json:"groupId"`
 	UserID   UserID    `json:"userId"`
 	Role     Role      `json:"role"`
 	JoinedAt time.Time `json:"joinedAt"`
+}
+
+func (m Membership) IsValid() bool {
+	return m.GroupID != "" && m.UserID != "" && m.Role != ""
 }
 
 func (m Membership) CanCreateEvents() bool {
@@ -69,6 +91,14 @@ type Event struct {
 	EndsAt      time.Time `json:"endsAt"`
 	CreatedBy   UserID    `json:"createdBy"`
 	Cancelled   bool      `json:"cancelled"`
+}
+
+func (e Event) IsValid() bool {
+	if e.ID == "" || e.GroupID == "" || e.Title == "" || e.CreatedBy == "" {
+		return false
+	}
+
+	return e.HasValidSchedule()
 }
 
 func (e Event) HasValidSchedule() bool {
@@ -108,6 +138,14 @@ type Poll struct {
 	AllowsRevoting bool          `json:"allowsRevoting"`
 }
 
+func (p Poll) IsValid() bool {
+	if p.ID == "" || p.GroupID == "" || p.Question == "" || p.CreatedBy == "" {
+		return false
+	}
+
+	return p.HasValidConfiguration()
+}
+
 func (p Poll) HasValidConfiguration() bool {
 	if len(p.Options) == 0 {
 		return false
@@ -127,6 +165,10 @@ func (p Poll) HasValidConfiguration() bool {
 type PollOption struct {
 	ID    string `json:"id"`
 	Label string `json:"label"`
+}
+
+func (o PollOption) IsValid() bool {
+	return o.ID != "" && o.Label != ""
 }
 
 type Vote struct {

--- a/backend/internal/domain/types_test.go
+++ b/backend/internal/domain/types_test.go
@@ -50,13 +50,17 @@ func TestRolePermissions(t *testing.T) {
 func TestMembershipDelegatesRolePermissions(t *testing.T) {
 	t.Parallel()
 
-	membership := Membership{Role: RoleOrganizer}
+	membership := Membership{GroupID: "group-1", UserID: "user-1", Role: RoleOrganizer}
 	if !membership.CanCreateEvents() {
 		t.Fatal("expected organizer membership to create events")
 	}
 
 	if !membership.CanRespond() {
 		t.Fatal("expected organizer membership to respond")
+	}
+
+	if !membership.IsValid() {
+		t.Fatal("expected membership with role and identities to be valid")
 	}
 }
 
@@ -74,6 +78,25 @@ func TestEventHasValidSchedule(t *testing.T) {
 	invalid := Event{StartsAt: end, EndsAt: start}
 	if invalid.HasValidSchedule() {
 		t.Fatal("expected reversed event schedule to be invalid")
+	}
+}
+
+func TestGroupAndMemberValidation(t *testing.T) {
+	t.Parallel()
+
+	group := Group{ID: "group-1", Slug: "platform", Name: "Platform"}
+	if !group.IsValid() {
+		t.Fatal("expected group with required fields to be valid")
+	}
+
+	member := Member{ID: "user-1", DisplayName: "Mustansar"}
+	if !member.IsValid() {
+		t.Fatal("expected member with required fields to be valid")
+	}
+
+	invalidMember := Member{ID: "user-2"}
+	if invalidMember.IsValid() {
+		t.Fatal("expected member without display name to be invalid")
 	}
 }
 
@@ -96,5 +119,44 @@ func TestPollHasValidConfiguration(t *testing.T) {
 	poll.MaxSelections = 3
 	if poll.HasValidConfiguration() {
 		t.Fatal("expected poll with too many max selections to be invalid")
+	}
+}
+
+func TestEventAndPollValidation(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.April, 20, 18, 0, 0, 0, time.UTC)
+	end := start.Add(90 * time.Minute)
+
+	event := Event{
+		ID:        "event-1",
+		GroupID:   "group-1",
+		Title:     "Quarterly planning",
+		StartsAt:  start,
+		EndsAt:    end,
+		CreatedBy: "user-1",
+	}
+	if !event.IsValid() {
+		t.Fatal("expected event with required fields and valid schedule to be valid")
+	}
+
+	poll := Poll{
+		ID:       "poll-1",
+		GroupID:  "group-1",
+		Question: "Pick a venue",
+		Options: []PollOption{
+			{ID: "one", Label: "Berlin"},
+			{ID: "two", Label: "London"},
+		},
+		MinSelections: 1,
+		MaxSelections: 1,
+		CreatedBy:     "user-1",
+	}
+	if !poll.IsValid() {
+		t.Fatal("expected poll with valid configuration to be valid")
+	}
+
+	if !poll.Options[0].IsValid() {
+		t.Fatal("expected poll option with id and label to be valid")
 	}
 }

--- a/backend/internal/sdui/types.go
+++ b/backend/internal/sdui/types.go
@@ -1,16 +1,46 @@
 package sdui
 
+// UIDescriptor defines the server-driven UI payload attached to API responses.
+// Validation rule: every component and action entry must be individually valid.
 type UIDescriptor struct {
 	Components []UIComponent `json:"components,omitempty"`
 	Actions    []UIAction    `json:"actions,omitempty"`
 }
 
+func (d UIDescriptor) IsValid() bool {
+	for _, component := range d.Components {
+		if !component.IsValid() {
+			return false
+		}
+	}
+
+	for _, action := range d.Actions {
+		if !action.IsValid() {
+			return false
+		}
+	}
+
+	return true
+}
+
+// UIComponent describes a renderable UI block.
+// Validation rule: type must be non-empty.
 type UIComponent struct {
 	Type string `json:"type"`
 	ID   string `json:"id,omitempty"`
 }
 
+func (c UIComponent) IsValid() bool {
+	return c.Type != ""
+}
+
+// UIAction describes an interaction surface emitted by the backend.
+// Validation rule: type must be non-empty.
 type UIAction struct {
 	Type   string `json:"type"`
 	Target string `json:"target,omitempty"`
+}
+
+func (a UIAction) IsValid() bool {
+	return a.Type != ""
 }

--- a/backend/internal/sdui/types_test.go
+++ b/backend/internal/sdui/types_test.go
@@ -1,0 +1,46 @@
+package sdui
+
+import "testing"
+
+func TestComponentAndActionValidation(t *testing.T) {
+	t.Parallel()
+
+	component := UIComponent{Type: "section", ID: "summary"}
+	if !component.IsValid() {
+		t.Fatal("expected UI component with type to be valid")
+	}
+
+	action := UIAction{Type: "navigate", Target: "/events"}
+	if !action.IsValid() {
+		t.Fatal("expected UI action with type to be valid")
+	}
+
+	invalidComponent := UIComponent{}
+	if invalidComponent.IsValid() {
+		t.Fatal("expected component without type to be invalid")
+	}
+
+	invalidAction := UIAction{}
+	if invalidAction.IsValid() {
+		t.Fatal("expected action without type to be invalid")
+	}
+}
+
+func TestDescriptorValidation(t *testing.T) {
+	t.Parallel()
+
+	descriptor := UIDescriptor{
+		Components: []UIComponent{{Type: "section", ID: "board"}},
+		Actions:    []UIAction{{Type: "submit", Target: "/polls/1/votes"}},
+	}
+	if !descriptor.IsValid() {
+		t.Fatal("expected descriptor with valid items to be valid")
+	}
+
+	invalidDescriptor := UIDescriptor{
+		Components: []UIComponent{{Type: "section"}, {}},
+	}
+	if invalidDescriptor.IsValid() {
+		t.Fatal("expected descriptor with invalid component to be invalid")
+	}
+}


### PR DESCRIPTION
## Summary\n- add missing core  model in \n- add validation helpers across Group/Member/Membership/Event/Poll/PollOption\n- document model validation rules with focused comments\n- add SDUI validation helpers for descriptor/components/actions\n- add unit tests for domain validation paths and SDUI payload validation\n\n## Validation\n- ?   	github.com/msamad/group-events/backend/cmd/api	[no test files]
?   	github.com/msamad/group-events/backend/internal/config	[no test files]
ok  	github.com/msamad/group-events/backend/internal/domain	(cached)
ok  	github.com/msamad/group-events/backend/internal/httpapi	(cached)
ok  	github.com/msamad/group-events/backend/internal/sdui	(cached)\n- \n\n## Issue\nCloses #5